### PR TITLE
Startup control for to coordinate database container and migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,25 +20,9 @@ The containers are now running, both the web service and the database service.  
 
     http://127.0.0.1:8000/
 
-At this point you will get an error from the SQL query
+At this point you will see that you have no stations.  This is because we haven't applied an initial data load from a fixture file.  
 
-    SELECT * from stations.station;
-
-This is because we haven't yet created a database in the db container.  I'll be looking into doing this automatically, but for now we will do this from the command line.
-
-Execute the following commands from the bash prompt at the root of the idastatus project...
-
-    docker exec docker-idastatus_db_1 psql -U postgres -w -p 5432 --command="CREATE DATABASE idastatus"
-
-    docker exec docker-idastatus_db_1 psql -U postgres -w -p 5432 --command="create user idadb with encrypted password 'password';"
-
-    docker exec docker-idastatus_db_1 psql -U postgres -w -p 5432 --command="grant all privileges on database idastatus to idadb;"
-
-This will create the idastatus database and the idadb user with sufficient privileges for development.  **NOTE!!! These privileges should not be used for production databases**
-
-At this point we need to apply database migrations to the database, as well as add data to the database using the fixtures files.  Execute the following commands...
-
-    docker-compose exec web python manage.py migrate --noinput
+Execute the following commands from the bash prompt at the root of the idastatus project, in this case: .../docker-idastatus/idastatus
 
     docker-compose exec web python manage.py loaddata stations/fixtures/initial_data.json
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,10 @@ services:
     build: 
       context: ./idastatus
 
-    command: python manage.py runserver 0.0.0.0:8000
+    #command: ./wait-for db:5432 -- echo "doing runserver"
+    command: ["./wait-for-postgres.sh", "db", "idadb", "password", "python manage.py runserver 0.0.0.0:8000"]
+    depends_on:
+      - db
 
     volumes:
       - ./idastatus:/ida/code/
@@ -27,15 +30,14 @@ services:
     links:
       - db
 
-    depends_on:
-      - db
-
 # this service will use same image, and once the migration is done it will be stopped
   web_migrations:
     build: 
       context: ./idastatus
 
-    command: python manage.py migrate
+    command: ["./wait-for-postgres.sh", "db", "idadb", "password", "python manage.py migrate"]
+    depends_on:
+      - db
 
 volumes:
   db-data:

--- a/idastatus/Dockerfile
+++ b/idastatus/Dockerfile
@@ -8,10 +8,9 @@ ENV PYTHONUNBUFFERED 1
 # install psycopg2
 RUN apt-get update \
     && apt-get -y install build-essential gcc python3-dev musl-dev \
-#    && apt-get -y install postgresql-dev \
+    && apt-get -y install postgresql-client \
     && apt-get -y install bash vim \
-    && pip install psycopg2-binary \
-    && apt-get -y remove build-essential
+    && pip install psycopg2-binary
 
 COPY requirements.txt /ida/code/
 

--- a/idastatus/wait-for-postgres.sh
+++ b/idastatus/wait-for-postgres.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# wait-for-postgres.sh
+
+set -e
+
+host="$1"
+shift
+user="$1"
+shift
+pass="$1"
+shift
+cmd="$@"
+
+until PGPASSWORD=$pass psql -h "$host" -U "$user" -d postgres -c '\q'; do
+  >&2 echo "Postgres is unavailable - sleeping"
+  sleep 1
+done
+
+>&2 echo "Postgres is up - executing command"
+exec $cmd


### PR DESCRIPTION
Updated README for current migration and fixtures work flow

Put in a startup control method to assure that the db is up and
running before the web_migrations and web containers are run